### PR TITLE
Fix Travis pushing PR test images to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ install:
 script:
   - npm test
   - npm run build
-after_success:
-  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
-      docker build -t ohtuprojektiilmo/ohtufront . ;
-      docker push ohtuprojektiilmo/ohtufront ;
-    fi;
+deploy:
+  provider: script
+  script: deploy_dockerhub.sh
+  on:
+    branch: master

--- a/deploy_dockerhub.sh
+++ b/deploy_dockerhub.sh
@@ -5,6 +5,6 @@
 #
 # DON'T RUN MANUALLY UNLESS YOU KNOW WHAT YOU'RE DOING! -Joona
 
-docker login -u $DOCKER_USERNAME -p $docker_password
+docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 docker build -t ohtuprojektiilmo/ohtufront .
 docker push ohtuprojektiilmo/ohtufront

--- a/deploy_dockerhub.sh
+++ b/deploy_dockerhub.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Deployment script used by Travis (.travis.yml) to push master's image to
+# DockerHub after successful merge
+#
+# DON'T RUN MANUALLY UNLESS YOU KNOW WHAT YOU'RE DOING! -Joona
+
+docker login -u $DOCKER_USERNAME -p $docker_password
+docker build -t ohtuprojektiilmo/ohtufront .
+docker push ohtuprojektiilmo/ohtufront


### PR DESCRIPTION
Travis was pushing images produced after test runs on pull request. This was
caused by .travis.yml having an "after_success" hook for deployment, instead of
using the "deploy" hook.