### PR TITLE
Registration details feature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -168,7 +168,13 @@ class App extends Component {
               <Route
                 exact
                 path="/registrationdetails"
-                render={() => <RegistrationDetailsPage />}
+                render={() =>
+                  this.props.user ? (
+                    <RegistrationDetailsPage />
+                  ) : (
+                    <Redirect to={'/login'} />
+                  )
+                }
               />
             </Switch>
           </div>

--- a/src/App.js
+++ b/src/App.js
@@ -199,7 +199,7 @@ const mapDispatchToProps = {
   ...loginPageActions,
   ...appActions,
   ...registrationmanagementActions,
-  ...registrationActions
+  clearRegistration: registrationActions.clearRegistration
 }
 
 const ConnectedApp = connect(

--- a/src/App.js
+++ b/src/App.js
@@ -122,7 +122,7 @@ class App extends Component {
               />
               <Route
                 exact
-                path={'/'}
+                path="/"
                 render={() =>
                   this.props.user ? <LandingPage /> : <Redirect to="/login" />
                 }

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ import appActions from './reducers/actions/appActions'
 import notificationActions from './reducers/actions/notificationActions'
 import loginPageActions from './reducers/actions/loginPageActions'
 import registrationmanagementActions from './reducers/actions/registrationManagementActions'
+import registrationActions from './reducers/actions/registrationActions'
 
 const history = createBrowserHistory({ basename: process.env.PUBLIC_URL })
 
@@ -43,6 +44,21 @@ class App extends Component {
       this.props.updateIsLoading(true)
       this.userCheck()
       this.props.updateIsLoading(false)
+    }
+  }
+
+  fetchRegistrationManagement = async () => {
+    try {
+      const response = await registrationManagementService.get()
+      this.props.setRegistrationManagement(response.registrationManagement)
+    } catch (e) {
+      console.log('error happened', e)
+      this.props.setError(
+        'Error fetching registration management configuration'
+      )
+      setTimeout(() => {
+        this.props.clearNotifications()
+      }, 5000)
     }
   }
 
@@ -62,25 +78,11 @@ class App extends Component {
     }
   }
 
-  fetchRegistrationManagement = async () => {
-    try {
-      const response = await registrationManagementService.get()
-      this.props.setRegistrationManagement(response.registrationManagement)
-    } catch (e) {
-      console.log('error happened', e)
-      this.props.setError(
-        'Error fetching registration management configuration'
-      )
-      setTimeout(() => {
-        this.props.clearNotifications()
-      }, 5000)
-    }
-  }
-
   logout() {
     this.props.updateIsLoading(true)
     window.localStorage.clear()
     this.props.updateUser('')
+    this.props.clearRegistration()
     this.props.updateIsLoading(false)
     history.push('/login')
   }
@@ -184,7 +186,8 @@ const mapDispatchToProps = {
   ...notificationActions,
   ...loginPageActions,
   ...appActions,
-  ...registrationmanagementActions
+  ...registrationmanagementActions,
+  ...registrationActions
 }
 
 const ConnectedApp = connect(

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import Notification from './components/common/Notification'
 import LoadingSpinner from './components/common/LoadingSpinner'
 import QuestionsFormPage from './components/QuestionsFormPage'
 import RegistrationManagementPage from './components/RegistrationManagementPage'
+import RegistrationDetailsPage from './components/RegistrationDetailsPage'
 
 // Services
 import registrationManagementService from './services/registrationManagement'
@@ -161,8 +162,13 @@ class App extends Component {
               <Route
                 exact
                 path="/administration/registrationmanagement"
-                user={this.props.user}
                 render={() => <RegistrationManagementPage />}
+              />
+
+              <Route
+                exact
+                path="/registrationdetails"
+                render={() => <RegistrationDetailsPage />}
               />
             </Switch>
           </div>

--- a/src/App.js
+++ b/src/App.js
@@ -124,7 +124,7 @@ class App extends Component {
                 exact
                 path={'/'}
                 render={() =>
-                  this.props.user ? <LandingPage /> : <Redirect to={'/login'} />
+                  this.props.user ? <LandingPage /> : <Redirect to="/login" />
                 }
               />
               <Route exact path="/topics" render={() => <TopicListPage />} />
@@ -172,7 +172,7 @@ class App extends Component {
                   this.props.user ? (
                     <RegistrationDetailsPage />
                   ) : (
-                    <Redirect to={'/login'} />
+                    <Redirect to="/login" />
                   )
                 }
               />

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -24,7 +24,7 @@ class LandingPage extends React.Component {
       <div className="landingpage-container">
         <h2 className="landingpage-header">Home</h2>
         {this.props.projectOpen ? (
-          <Link to='/register'>Submit your registration</Link>
+          <Link to="/register">Submit your registration</Link>
         ) : (
           <div className="landingpage-message">{this.props.projectMessage}</div>
         )}

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -4,23 +4,18 @@ import { withRouter, Link } from 'react-router-dom'
 
 import './LandingPage.css'
 
-import registrationService from '../services/registration'
-
 import notificationActions from '../reducers/actions/notificationActions'
 import registrationActions from '../reducers/actions/registrationActions'
 
 class LandingPage extends React.Component {
   componentDidMount() {
-    this.fetchOwnRegistration()
+    this.fetchOwnregistration()
   }
 
-  fetchOwnRegistration = async () => {
-    const response = await registrationService.getOwn()
-    if (response) {
-      this.props.setRegistration(response)
+  fetchOwnregistration = async () => {
+    await this.props.fetchRegistration()
+    if (this.props.ownRegistration) {
       this.props.history.push('/registrationdetails')
-    } else {
-      this.props.clearRegistration()
     }
   }
 
@@ -43,13 +38,14 @@ class LandingPage extends React.Component {
 const mapStateToProps = (state) => {
   return {
     projectOpen: state.registrationManagement.projectRegistrationOpen,
-    projectMessage: state.registrationManagement.projectRegistrationMessage
+    projectMessage: state.registrationManagement.projectRegistrationMessage,
+    ownRegistration: state.registration
   }
 }
 
 const mapDispatchToProps = {
   ...notificationActions,
-  ...registrationActions
+  fetchRegistration: registrationActions.fetchRegistration
 }
 
 const ConnectedLandingPage = connect(

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -24,7 +24,7 @@ class LandingPage extends React.Component {
       <div className="landingpage-container">
         <h2 className="landingpage-header">Home</h2>
         {this.props.projectOpen ? (
-          <Link to={'/register'}>Submit your registration</Link>
+          <Link to='/register'>Submit your registration</Link>
         ) : (
           <div className="landingpage-message">{this.props.projectMessage}</div>
         )}

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -1,18 +1,40 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Link } from 'react-router-dom'
+import { withRouter, Link } from 'react-router-dom'
 
 import './LandingPage.css'
 
+import registrationService from '../services/registration'
+
 import notificationActions from '../reducers/actions/notificationActions'
+import registrationActions from '../reducers/actions/registrationActions'
 
 class LandingPage extends React.Component {
+  componentDidMount() {
+    this.fetchOwnRegistration()
+  }
+
+  fetchOwnRegistration = async () => {
+    const response = await registrationService.getOwn()
+    if (response) {
+      this.props.setRegistration(response)
+    } else {
+      this.props.clearRegistration()
+    }
+  }
+
   render() {
     return (
       <div className="landingpage-container">
         <h2 className="landingpage-header">Home</h2>
         {this.props.projectOpen ? (
-          <Link to={'/register'}>Submit your registration</Link>
+          this.props.ownRegistration ? (
+            <div>You are already registered</div>
+          ) : (
+            <Link to={process.env.PUBLIC_URL + '/register'}>
+              Submit your registration
+            </Link>
+          )
         ) : (
           <div className="landingpage-message">{this.props.projectMessage}</div>
         )}
@@ -24,12 +46,14 @@ class LandingPage extends React.Component {
 const mapStateToProps = (state) => {
   return {
     projectOpen: state.registrationManagement.projectRegistrationOpen,
-    projectMessage: state.registrationManagement.projectRegistrationMessage
+    projectMessage: state.registrationManagement.projectRegistrationMessage,
+    ownRegistration: state.registration
   }
 }
 
 const mapDispatchToProps = {
-  ...notificationActions
+  ...notificationActions,
+  ...registrationActions
 }
 
 const ConnectedLandingPage = connect(
@@ -37,4 +61,4 @@ const ConnectedLandingPage = connect(
   mapDispatchToProps
 )(LandingPage)
 
-export default ConnectedLandingPage
+export default withRouter(ConnectedLandingPage)

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -18,6 +18,7 @@ class LandingPage extends React.Component {
     const response = await registrationService.getOwn()
     if (response) {
       this.props.setRegistration(response)
+      this.props.history.push('/registrationdetails')
     } else {
       this.props.clearRegistration()
     }
@@ -28,13 +29,9 @@ class LandingPage extends React.Component {
       <div className="landingpage-container">
         <h2 className="landingpage-header">Home</h2>
         {this.props.projectOpen ? (
-          this.props.ownRegistration ? (
-            <div>You are already registered</div>
-          ) : (
-            <Link to={process.env.PUBLIC_URL + '/register'}>
-              Submit your registration
-            </Link>
-          )
+          <Link to={process.env.PUBLIC_URL + '/register'}>
+            Submit your registration
+          </Link>
         ) : (
           <div className="landingpage-message">{this.props.projectMessage}</div>
         )}
@@ -46,8 +43,7 @@ class LandingPage extends React.Component {
 const mapStateToProps = (state) => {
   return {
     projectOpen: state.registrationManagement.projectRegistrationOpen,
-    projectMessage: state.registrationManagement.projectRegistrationMessage,
-    ownRegistration: state.registration
+    projectMessage: state.registrationManagement.projectRegistrationMessage
   }
 }
 

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -24,9 +24,7 @@ class LandingPage extends React.Component {
       <div className="landingpage-container">
         <h2 className="landingpage-header">Home</h2>
         {this.props.projectOpen ? (
-          <Link to={process.env.PUBLIC_URL + '/register'}>
-            Submit your registration
-          </Link>
+          <Link to={'/register'}>Submit your registration</Link>
         ) : (
           <div className="landingpage-message">{this.props.projectMessage}</div>
         )}

--- a/src/components/RegistrationDetailsPage.css
+++ b/src/components/RegistrationDetailsPage.css
@@ -1,0 +1,22 @@
+.dragndrop-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.dragndrop-list {
+  flex: 99;
+}
+
+.dragndrop-indexes-container {
+  flex: 1;
+  height: 80px;
+}
+
+.dragndrop-index {
+  padding: 30px 20px 30px 20px;
+  max-height: 18px;
+  margin: 2px;
+  font-weight: bold;
+  font-family: 'Roboto', sans-serif;
+  color: #4d4d4d;
+}

--- a/src/components/RegistrationDetailsPage.js
+++ b/src/components/RegistrationDetailsPage.js
@@ -1,15 +1,20 @@
 import React from 'react'
 import { withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
+import ReactDragList from 'react-drag-list'
 
 import registrationActions from '../reducers/actions/registrationActions'
 
 import Typography from '@material-ui/core/Typography'
+import { Input, Card, CardContent, Select, MenuItem } from '@material-ui/core'
+import TopicDialog from './TopicDialog'
+
+import './RegistrationDetailsPage.css'
 
 class RegistrationDetailsPage extends React.Component {
   render() {
     const registration = this.props.ownRegistration
-    const { student, preferred_topics, questions } = registration
+    const { student, preferred_topics, questions, createdAt } = registration
     const { first_names, last_name, student_number, email } = student
 
     let firstname = ''
@@ -18,80 +23,76 @@ class RegistrationDetailsPage extends React.Component {
     }
     firstname = firstname.split(' ')[0]
 
-    const sortedQuestions = questions.sort((a, b) => {
-      if (a.type === 'scale' && b.type !== 'scale') {
-        return -1
-      } else if (a.type !== 'scale' && b.type === 'scale') {
-        return 1
-      }
-      return 0
-    })
-
-    const firstOpenTextQuestion = sortedQuestions.findIndex((question) => {
-      if (question.type === 'text') {
-        return true
-      }
-      return false
-    })
-
-    const scaleQuestions = sortedQuestions.slice(0, firstOpenTextQuestion)
-    const openTextquestions = sortedQuestions.slice(firstOpenTextQuestion)
+    const submittedDate = createdAt.replace(/T/, ' ').substr(0, 16)
 
     return (
       <div>
         <Typography variant="h4" gutterBottom>
           Registration details
         </Typography>
+        <Typography variant="body1" gutterBottom>
+          Registration date: {submittedDate}
+        </Typography>
         <div>
-          <Typography variant="h5" gutterBottom>
-            User details
-          </Typography>
+          <h2>User details</h2>
           <Typography variant="body1" gutterBottom>
             Name: {firstname} {last_name}
             <br />
             Student number: {student_number}
             <br />
             Email: {email}
-            <br />
           </Typography>
         </div>
         <div>
-          <Typography variant="h5" gutterBottom>
-            Preferred topics
-          </Typography>
-          {preferred_topics.map((topic, index) => {
-            const { title, customerName } = topic.content
-            return (
-              <Typography variant="body1" gutterBottom key={index}>
-                {index + 1}. {title} from {customerName}
-              </Typography>
-            )
-          })}
+          <h2>Preferred Topics</h2>
+          <div className="dragndrop-container">
+            <div className="dragndrop-indexes-container">
+              {preferred_topics.map((topic, index) => {
+                return (
+                  <Card key={index} className="dragndrop-index">
+                    {index + 1}
+                  </Card>
+                )
+              })}
+            </div>
+            <ReactDragList
+              className="dragndrop-list"
+              handles={false}
+              dataSource={preferred_topics}
+              rowKey="id"
+              row={(topic) => {
+                return <TopicDialog topic={topic} key={topic.content.title} />
+              }}
+              disabled
+            />
+          </div>
         </div>
         <div>
-          <Typography variant="h5" gutterBottom>
-            Answers to questions
-          </Typography>
-          <Typography variant="h6" gutterBottom>
-            Scale (0-5) questions
-          </Typography>
-          {scaleQuestions.map((question, index) => {
+          <h2>Details</h2>
+          {questions.map((question, index) => {
             return (
-              <Typography variant="body1" gutterBottom key={index}>
-                {question.question}: {question.answer}
-              </Typography>
-            )
-          })}
-          <Typography variant="h6" gutterBottom>
-            Open text questions
-          </Typography>
-          {openTextquestions.map((question, index) => {
-            return (
-              <Typography variant="body1" gutterBottom key={index}>
-                Question: {question.question}
-                <br />
-                Answer: {question.answer}
-              </Typography>
+              <Card style={{ marginBottom: '10px' }} key={index}>
+                <CardContent>
+                  <Typography variant="body1">{question.question}</Typography>
+                  {question.type === 'scale' ? (
+                    <Select value={question.answer} disabled>
+                      <MenuItem value={1}>1</MenuItem>
+                      <MenuItem value={2}>2</MenuItem>
+                      <MenuItem value={3}>3</MenuItem>
+                      <MenuItem value={4}>4</MenuItem>
+                      <MenuItem value={5}>5</MenuItem>
+                    </Select>
+                  ) : (
+                    <Input
+                      value={question.answer}
+                      fullWidth
+                      multiline
+                      rowsMax="3"
+                      disabled
+                    />
+                  )}
+                </CardContent>
+              </Card>
             )
           })}
         </div>

--- a/src/components/RegistrationDetailsPage.js
+++ b/src/components/RegistrationDetailsPage.js
@@ -11,19 +11,111 @@ import TopicDialog from './TopicDialog'
 
 import './RegistrationDetailsPage.css'
 
+const UserDetails = ({ student }) => {
+  const { first_names, last_name, student_number, email } = student
+
+  const extractCallingName = (firstNames) => {
+    if (firstNames.includes('*')) {
+      return first_names.split('*')[1].split(' ')[0]
+    }
+    return firstNames.split(' ')[0]
+  }
+
+  return (
+    <div>
+      <h2>User details</h2>
+      <Typography variant="body1" gutterBottom>
+        Name: {extractCallingName(first_names)} {last_name}
+        <br />
+        Student number: {student_number}
+        <br />
+        Email: {email}
+      </Typography>
+    </div>
+  )
+}
+
+const PreferredTopics = ({ topics }) => {
+  return (
+    <div>
+      <h2>Preferred Topics</h2>
+      <div className="dragndrop-container">
+        <div className="dragndrop-indexes-container">
+          {topics.map((topic, index) => {
+            return (
+              <Card key={index} className="dragndrop-index">
+                {index + 1}
+              </Card>
+            )
+          })}
+        </div>
+        <ReactDragList
+          className="dragndrop-list"
+          handles={false}
+          dataSource={topics}
+          rowKey="id"
+          row={(topic) => {
+            return <TopicDialog topic={topic} key={topic.content.title} />
+          }}
+          disabled
+        />
+      </div>
+    </div>
+  )
+}
+
+const RegistrationAnswers = ({ questions }) => {
+  return (
+    <div>
+      <h2>Answers</h2>
+      {questions.map((question, index) => {
+        return (
+          <Card style={{ marginBottom: '10px' }} key={index}>
+            <CardContent>
+              <Typography variant="body1">{question.question}</Typography>
+              {question.type === 'scale' ? (
+                <Select value={question.answer} disabled>
+                  <MenuItem value={0}>0</MenuItem>
+                  <MenuItem value={1}>1</MenuItem>
+                  <MenuItem value={2}>2</MenuItem>
+                  <MenuItem value={3}>3</MenuItem>
+                  <MenuItem value={4}>4</MenuItem>
+                  <MenuItem value={5}>5</MenuItem>
+                </Select>
+              ) : (
+                <Input
+                  value={question.answer}
+                  fullWidth
+                  multiline
+                  rowsMax="3"
+                  disabled
+                />
+              )}
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}
+
 class RegistrationDetailsPage extends React.Component {
   render() {
-    const registration = this.props.ownRegistration
-    const { student, preferred_topics, questions, createdAt } = registration
-    const { first_names, last_name, student_number, email } = student
+    const {
+      student,
+      preferred_topics,
+      questions,
+      createdAt
+    } = this.props.ownRegistration
 
-    let firstname = ''
-    if (first_names.includes('*')) {
-      firstname = first_names.split('*')[1]
+    /**
+     * Format datetime
+     * eg. from 2019-02-07T10:57:19.122Z to 7.2.2019 12.57
+     */
+    const formatDate = (date) => {
+      const parsedDate = new Date(date).toLocaleString('fi-FI')
+      return parsedDate.slice(0, parsedDate.lastIndexOf('.')).replace('klo', '')
     }
-    firstname = firstname.split(' ')[0]
-
-    const submittedDate = createdAt.replace(/T/, ' ').substr(0, 16)
 
     return (
       <div>
@@ -31,72 +123,11 @@ class RegistrationDetailsPage extends React.Component {
           Registration details
         </Typography>
         <Typography variant="body1" gutterBottom>
-          Registration date: {submittedDate}
+          Registration date: {formatDate(createdAt)}
         </Typography>
-        <div>
-          <h2>User details</h2>
-          <Typography variant="body1" gutterBottom>
-            Name: {firstname} {last_name}
-            <br />
-            Student number: {student_number}
-            <br />
-            Email: {email}
-          </Typography>
-        </div>
-        <div>
-          <h2>Preferred Topics</h2>
-          <div className="dragndrop-container">
-            <div className="dragndrop-indexes-container">
-              {preferred_topics.map((topic, index) => {
-                return (
-                  <Card key={index} className="dragndrop-index">
-                    {index + 1}
-                  </Card>
-                )
-              })}
-            </div>
-            <ReactDragList
-              className="dragndrop-list"
-              handles={false}
-              dataSource={preferred_topics}
-              rowKey="id"
-              row={(topic) => {
-                return <TopicDialog topic={topic} key={topic.content.title} />
-              }}
-              disabled
-            />
-          </div>
-        </div>
-        <div>
-          <h2>Details</h2>
-          {questions.map((question, index) => {
-            return (
-              <Card style={{ marginBottom: '10px' }} key={index}>
-                <CardContent>
-                  <Typography variant="body1">{question.question}</Typography>
-                  {question.type === 'scale' ? (
-                    <Select value={question.answer} disabled>
-                      <MenuItem value={0}>0</MenuItem>
-                      <MenuItem value={1}>1</MenuItem>
-                      <MenuItem value={2}>2</MenuItem>
-                      <MenuItem value={3}>3</MenuItem>
-                      <MenuItem value={4}>4</MenuItem>
-                      <MenuItem value={5}>5</MenuItem>
-                    </Select>
-                  ) : (
-                    <Input
-                      value={question.answer}
-                      fullWidth
-                      multiline
-                      rowsMax="3"
-                      disabled
-                    />
-                  )}
-                </CardContent>
-              </Card>
-            )
-          })}
-        </div>
+        <UserDetails student={student} />
+        <PreferredTopics topics={preferred_topics} />
+        <RegistrationAnswers questions={questions} />
       </div>
     )
   }

--- a/src/components/RegistrationDetailsPage.js
+++ b/src/components/RegistrationDetailsPage.js
@@ -4,11 +4,97 @@ import { connect } from 'react-redux'
 
 import registrationActions from '../reducers/actions/registrationActions'
 
+import Typography from '@material-ui/core/Typography'
+
 class RegistrationDetailsPage extends React.Component {
   render() {
+    const registration = this.props.ownRegistration
+    const { student, preferred_topics, questions } = registration
+    const { first_names, last_name, student_number, email } = student
+
+    let firstname = ''
+    if (first_names.includes('*')) {
+      firstname = first_names.split('*')[1]
+    }
+    firstname = firstname.split(' ')[0]
+
+    const sortedQuestions = questions.sort((a, b) => {
+      if (a.type === 'scale' && b.type !== 'scale') {
+        return -1
+      } else if (a.type !== 'scale' && b.type === 'scale') {
+        return 1
+      }
+      return 0
+    })
+
+    const firstOpenTextQuestion = sortedQuestions.findIndex((question) => {
+      if (question.type === 'text') {
+        return true
+      }
+      return false
+    })
+
+    const scaleQuestions = sortedQuestions.slice(0, firstOpenTextQuestion)
+    const openTextquestions = sortedQuestions.slice(firstOpenTextQuestion)
+
     return (
       <div>
-        <p>Here are the registration details someday...</p>
+        <Typography variant="h4" gutterBottom>
+          Registration details
+        </Typography>
+        <div>
+          <Typography variant="h5" gutterBottom>
+            User details
+          </Typography>
+          <Typography variant="body1" gutterBottom>
+            Name: {firstname} {last_name}
+            <br />
+            Student number: {student_number}
+            <br />
+            Email: {email}
+            <br />
+          </Typography>
+        </div>
+        <div>
+          <Typography variant="h5" gutterBottom>
+            Preferred topics
+          </Typography>
+          {preferred_topics.map((topic, index) => {
+            const { title, customerName } = topic.content
+            return (
+              <Typography variant="body1" gutterBottom key={index}>
+                {index + 1}. {title} from {customerName}
+              </Typography>
+            )
+          })}
+        </div>
+        <div>
+          <Typography variant="h5" gutterBottom>
+            Answers to questions
+          </Typography>
+          <Typography variant="h6" gutterBottom>
+            Scale (0-5) questions
+          </Typography>
+          {scaleQuestions.map((question, index) => {
+            return (
+              <Typography variant="body1" gutterBottom key={index}>
+                {question.question}: {question.answer}
+              </Typography>
+            )
+          })}
+          <Typography variant="h6" gutterBottom>
+            Open text questions
+          </Typography>
+          {openTextquestions.map((question, index) => {
+            return (
+              <Typography variant="body1" gutterBottom key={index}>
+                Question: {question.question}
+                <br />
+                Answer: {question.answer}
+              </Typography>
+            )
+          })}
+        </div>
       </div>
     )
   }

--- a/src/components/RegistrationDetailsPage.js
+++ b/src/components/RegistrationDetailsPage.js
@@ -1,4 +1,8 @@
 import React from 'react'
+import { withRouter } from 'react-router-dom'
+import { connect } from 'react-redux'
+
+import registrationActions from '../reducers/actions/registrationActions'
 
 class RegistrationDetailsPage extends React.Component {
   render() {
@@ -10,4 +14,19 @@ class RegistrationDetailsPage extends React.Component {
   }
 }
 
-export default RegistrationDetailsPage
+const mapStateToProps = (state) => {
+  return {
+    ownRegistration: state.registration
+  }
+}
+
+const mapDispatchToProps = {
+  fetchRegistration: registrationActions.fetchRegistration
+}
+
+const ConnectedRegistrationDetailsPage = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RegistrationDetailsPage)
+
+export default withRouter(ConnectedRegistrationDetailsPage)

--- a/src/components/RegistrationDetailsPage.js
+++ b/src/components/RegistrationDetailsPage.js
@@ -76,6 +76,7 @@ class RegistrationDetailsPage extends React.Component {
                   <Typography variant="body1">{question.question}</Typography>
                   {question.type === 'scale' ? (
                     <Select value={question.answer} disabled>
+                      <MenuItem value={0}>0</MenuItem>
                       <MenuItem value={1}>1</MenuItem>
                       <MenuItem value={2}>2</MenuItem>
                       <MenuItem value={3}>3</MenuItem>

--- a/src/components/RegistrationDetailsPage.js
+++ b/src/components/RegistrationDetailsPage.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+class RegistrationDetailsPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <p>Here are the registration details someday...</p>
+      </div>
+    )
+  }
+}
+
+export default RegistrationDetailsPage

--- a/src/reducers/actions/registrationActions.js
+++ b/src/reducers/actions/registrationActions.js
@@ -1,9 +1,4 @@
-const setRegistration = (registration) => {
-  return {
-    type: 'SET_REGISTRATION',
-    payload: registration
-  }
-}
+import registrationService from '../../services/registration'
 
 const clearRegistration = () => {
   return {
@@ -11,4 +6,20 @@ const clearRegistration = () => {
   }
 }
 
-export default { setRegistration, clearRegistration }
+const fetchRegistration = () => {
+  return async (dispatch) => {
+    const registration = await registrationService.getOwn()
+    if (registration) {
+      dispatch({
+        type: 'SET_REGISTRATION',
+        payload: registration
+      })
+    } else {
+      dispatch({
+        type: 'CLEAR_REGISTRATION'
+      })
+    }
+  }
+}
+
+export default { clearRegistration, fetchRegistration }

--- a/src/reducers/actions/registrationActions.js
+++ b/src/reducers/actions/registrationActions.js
@@ -1,0 +1,14 @@
+const setRegistration = (registration) => {
+  return {
+    type: 'SET_REGISTRATION',
+    payload: registration
+  }
+}
+
+const clearRegistration = () => {
+  return {
+    type: 'CLEAR_REGISTRATION'
+  }
+}
+
+export default { setRegistration, clearRegistration }

--- a/src/reducers/registrationReducer.js
+++ b/src/reducers/registrationReducer.js
@@ -1,0 +1,14 @@
+const registrationReducer = (state = null, action) => {
+  switch (action.type) {
+  case 'SET_REGISTRATION':
+    return {
+      ...action.payload
+    }
+  case 'CLEAR_REGISTRATION':
+    return null
+  default:
+    return state
+  }
+}
+
+export default registrationReducer

--- a/src/reducers/store.js
+++ b/src/reducers/store.js
@@ -12,6 +12,7 @@ import registrationPageReducer from './registrationPageReducer'
 import adminPageReducer from './adminPageReducer'
 import questionsFormPageReducer from './questionsFormPageReducer'
 import registrationManagementReducer from './registrationManagementReducer'
+import registrationReducer from './registrationReducer'
 
 // Combine imported reducers
 const reducer = combineReducers({
@@ -24,7 +25,8 @@ const reducer = combineReducers({
   registrationPage: registrationPageReducer,
   adminPage: adminPageReducer,
   questionsFormPage: questionsFormPageReducer,
-  registrationManagement: registrationManagementReducer
+  registrationManagement: registrationManagementReducer,
+  registration: registrationReducer
 })
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose

--- a/src/services/registration.js
+++ b/src/services/registration.js
@@ -13,4 +13,15 @@ const create = async ({ questions, preferred_topics }) => {
   return response.data.registration
 }
 
-export default { create }
+const getOwn = async () => {
+  const response = await axios.get(url, {
+    headers: { Authorization: 'Bearer ' + getUserToken() }
+  })
+  console.log('registration service', response)
+  if (response.status === 204) {
+    return null
+  }
+  return response.data.registration
+}
+
+export default { create, getOwn }

--- a/src/services/registration.js
+++ b/src/services/registration.js
@@ -17,7 +17,6 @@ const getOwn = async () => {
   const response = await axios.get(url, {
     headers: { Authorization: 'Bearer ' + getUserToken() }
   })
-  console.log('registration service', response)
   if (response.status === 204) {
     return null
   }

--- a/src/services/registration.js
+++ b/src/services/registration.js
@@ -17,6 +17,11 @@ const getOwn = async () => {
   const response = await axios.get(url, {
     headers: { Authorization: 'Bearer ' + getUserToken() }
   })
+
+  /**
+   * Backend returns 204 when there is no registration to current
+   * iteration made by user fetching the registrationdetails
+   */
   if (response.status === 204) {
     return null
   }


### PR DESCRIPTION
This pull request serves for a purpose of letting users browse their own registration for currently ongoing iteration of software engineering project.

User who has not registered to currently ongoing iteration of SE project, will we directed to landing page as usual. However user who has already registered to SE project will be directed to his/her own registrations details. Later we can add functionality for editing ones own registration (if allowed) and showing maybe info on SE project group on the same page.

I tried to program this feature by the standards which we have agreed to use, but in case of I missed something, please review and comment.