### PR TITLE
Change hardcoded backend URI to relative /api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,15 @@ Sign up tool for University of Helsinki's software production course
 ## Instructions
 - [How to start frontend, backend and database using docker-compose](https://github.com/ohtuprojekti-ilmo/ohtuilmo-frontend/wiki)
 
-### How to start only frontend
+### How to start frontend for local development
 - Clone project
-- Create .env file to the project root and add address to backend server (ie. `http://localhost:3001` if you're running backend in port 3001)
-
-```
-REACT_APP_BACKEND_URI='backend server address'
-```
-
+- Start the backend server on `localhost:7001` or change package.json's "proxy" address to point to wherever you're running the backend in local development
+    - Easiest way is to use docker-compose and set the backend's host port to `7001`
 - Run project
-
-```
-$ npm install
-$ npm start
-```
+    ```
+    $ npm install
+    $ npm start
+    ```
 
 ### Docker instructions
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "http://svm-45.cs.helsinki.fi/projekti",
+  "proxy": {
+    "/api": {
+      "target": "http://localhost:7001"
+    }
+  },
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "@material-ui/core": "^3.6.0",

--- a/src/services/configuration.js
+++ b/src/services/configuration.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/configurations`
+const url = `${BACKEND_API_BASE}/configurations`
 
 const getAll = async () => {
   const response = await axios.get(url, {

--- a/src/services/email.js
+++ b/src/services/email.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 
-const url = `${BACKEND_URI}/api/email`
+const url = `${BACKEND_API_BASE}/email`
 
 const sendCustomerEmail = async (address, messageType) => {
   const response = await axios.post(url + '/send', { address, messageType })

--- a/src/services/login.js
+++ b/src/services/login.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 
-const url = `${BACKEND_URI}/api/login`
+const url = `${BACKEND_API_BASE}/login`
 
 const login = async (credentials) => {
   const response = await axios.post(url, credentials)

--- a/src/services/registration.js
+++ b/src/services/registration.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/registrations`
+const url = `${BACKEND_API_BASE}/registrations`
 
 const create = async ({ questions, preferred_topics }) => {
   const response = await axios.post(

--- a/src/services/registrationManagement.js
+++ b/src/services/registrationManagement.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/registrationManagement`
+const url = `${BACKEND_API_BASE}/registrationManagement`
 
 const get = async () => {
   const response = await axios.get(url)

--- a/src/services/registrationQuestionSet.js
+++ b/src/services/registrationQuestionSet.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/registrationQuestions`
+const url = `${BACKEND_API_BASE}/registrationQuestions`
 
 const create = async (registrationQuestionSet) => {
   const config = {

--- a/src/services/reviewQuestionSet.js
+++ b/src/services/reviewQuestionSet.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/reviewQuestions`
+const url = `${BACKEND_API_BASE}/reviewQuestions`
 
 const create = async (reviewQuestionSet) => {
   const config = {

--- a/src/services/tokenCheck.js
+++ b/src/services/tokenCheck.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 
-const url = `${BACKEND_URI}/api/tokenCheck`
+const url = `${BACKEND_API_BASE}/tokenCheck`
 
 const userCheck = async (token) => {
   const response = await axios.get(url + '/login', { headers: { 'Authorization': 'Bearer ' + token } })

--- a/src/services/topic.js
+++ b/src/services/topic.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/topics`
+const url = `${BACKEND_API_BASE}/topics`
 
 const create = async (content) => {
   const response = await axios.post(url, content)

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { BACKEND_URI } from '../utils/config'
+import { BACKEND_API_BASE } from '../utils/config'
 import { getUserToken } from '../utils/functions'
 
-const url = `${BACKEND_URI}/api/users`
+const url = `${BACKEND_API_BASE}/users`
 
 const update = async (user) => {
   const config = {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,13 +1,8 @@
-let BACKEND_URI = process.env.REACT_APP_BACKEND_URI
+// We can just request /api instead of making requests to a hardcoded/injected
+// backend URL since nginx will proxy /api to the backend.
+//
+// When in local dev, react-scripts knows how to proxy these calls according
+// to package.json's "proxy".
 
-if (window.location.hostname === 'svm-61.cs.helsinki.fi') {
-  BACKEND_URI = 'http://svm-61.cs.helsinki.fi/projekti-backend'
-} else if (window.location.hostname === 'svm-45.cs.helsinki.fi') {
-  BACKEND_URI = 'https://studies.cs.helsinki.fi/projekti-backend'
-} else if (window.location.hostname === 'studies.cs.helsinki.fi') {
-  BACKEND_URI = 'https://studies.cs.helsinki.fi/projekti-backend'
-}
-
-if (!BACKEND_URI) BACKEND_URI = 'http://localhost:7001'
-
-export { BACKEND_URI }
+const BACKEND_API_BASE = '/api'
+export { BACKEND_API_BASE }


### PR DESCRIPTION
Changes the hardcoded backend URI selection logic to just select "/api" as the
backend API base url.

To support this in local dev, "proxy" has been added to
package.json which react-scripts will use to proxy all /api requests to the
backend specified there. Will require you to have backend running on port 7001
in local dev, you can also just change the port while developing and then just
not commit the change.

To support this change in staging, a new locaion & rewrite rule has been added.
Production's nginx config will require the same change.