### PR TITLE
Add .prettierc and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "eslintIntegration": true,
+  "arrowParens": "always",
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 80
+}


### PR DESCRIPTION
node_modules does not need to be copied over to docker as docker will install them according to the dockerfile.