### PR TITLE
Deploy image tagged with commit ID in addition to latest

### DIFF
--- a/deploy_dockerhub.sh
+++ b/deploy_dockerhub.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
+set -e
+
 # Deployment script used by Travis (.travis.yml) to push master's image to
 # DockerHub after successful merge
 #
 # DON'T RUN MANUALLY UNLESS YOU KNOW WHAT YOU'RE DOING! -Joona
 
-DOCKER_TAG_NAME=ohtuprojektiilmo/ohtufront
+DOCKER_IMAGE_REPO=ohtuprojektiilmo/ohtufront
+DOCKER_TAG="$(git rev-parse --short ${TRAVIS_COMMIT})"
 
 echo 'Logging in with Docker'
-docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-echo "Building $DOCKER_TAG_NAME"
-docker build -t $DOCKER_TAG_NAME .
+echo "Building $DOCKER_IMAGE_REPO:$DOCKER_TAG"
+docker build -t "$DOCKER_IMAGE_REPO:$DOCKER_TAG" .
+docker tag "$DOCKER_IMAGE_REPO:$DOCKER_TAG" "$DOCKER_IMAGE_REPO:latest"
 
 echo 'Pushing to dockerhub'
-docker push $DOCKER_TAG_NAME
+docker push "$DOCKER_IMAGE_REPO:$DOCKER_TAG"
+docker push "$DOCKER_IMAGE_REPO:latest"
 
 echo 'Deployed!'


### PR DESCRIPTION
This PR will make the deployment script tag the image with the short commit hash in addition to creating the latest tag.

For example, running deploy on this branch would lead to two new images:

```
ohtuprojektiilmo/ohtufront:latest
ohtuprojektiilmo/ohtufront:fd4b40f
```

where `:latest` and `:fd4b40f` both point at the same image.

When deploying, this will allow us to know which version is currently deployed. We will also be able to roll back broken releases.

Plus, it's free.